### PR TITLE
Update .gitignore to ignore certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@ __pycache__
 .pytest_cache
 *helm-generated/
 kubernetes/.packaged
+
+# Prevent certificates from getting checked in
+*.ca
+*.cer
+*.crt
+*.csr
+*.key
+*.pem


### PR DESCRIPTION
Update .gitignore to ignore certificates to help prevent check in of sensitive files in the future.